### PR TITLE
Stops reorder

### DIFF
--- a/frontend/src/templates/routes/routes-planner.js
+++ b/frontend/src/templates/routes/routes-planner.js
@@ -64,6 +64,63 @@ class BusRoutesPlanner extends Component {
         }))
     }
 
+    handleReorder = (new_order) => {
+        console.log(this.state.stops)
+        console.log(new_order)
+        this.setState({ stops_order: new_order })
+    }
+
+    submitStopsOrder = () => {
+        this.switchStopsEditMode()
+
+        // reorder stops array to be nice
+        const ordered_stops = [...this.state.stops]
+        const order = [...this.state.stops_order]
+        ordered_stops.sort((a, b) => {
+            return order.indexOf(a.id) - order.indexOf(b.id)
+        })
+        
+        // make api req
+        const edit_body = {
+            stops: ordered_stops.map(stop => {
+                return {
+                    id: stop.id,
+                    route_id: this.state.active_route,
+                    name: stop.name,
+                    arrival: stop.arrival,
+                    departure: stop.departure,
+                    lat: stop.location.lat,
+                    long: stop.location.long
+                }
+            }            
+        )}
+        
+        console.log(edit_body)
+        api.put(`stops/edit`, edit_body)
+        .then(res => {
+            const success = res.data.success
+            const new_stops = res.data.stops
+            console.log(new_stops)
+            const new_stops_by_id = new_stops.map(stop => {
+                return stop.id
+            })
+            console.log(new_stops_by_id)
+            if (success) {
+                // console.log(this.state.stops)
+                // const orig_stops = [...this.state.stops]
+                // const ordered_stops = orig_stops.map(stop => {
+                //     return {
+                //         ...stop,
+                //         order_by: new_stops[new_stops_by_id.indexOf(stop.id)].order_by
+                //     }
+                // })
+                // console.log(ordered_stops)
+                // this.setState({ stops: ordered_stops })
+                this.handleStopsGet()
+            }
+        })
+    }
+
     switchStopsEditMode = () => {
         this.setState(prevState => ({
             stops_edit_mode: !prevState.stops_edit_mode
@@ -71,16 +128,6 @@ class BusRoutesPlanner extends Component {
         this.setState(prevState => ({
             dnd: !prevState.dnd
         }))
-    }
-
-    handleReorder = (new_order) => {
-        this.setState({ stops_order: new_order })
-    }
-
-    submitStopsOrder = () => {
-        this.switchStopsEditMode()
-        // TODO: add axios get for stops reordering @jessica
-        
     }
 
     handleTableGet = () => {        

--- a/frontend/src/templates/tables/stops-table.js
+++ b/frontend/src/templates/tables/stops-table.js
@@ -46,6 +46,11 @@ export function StopsTable({ data, showAll, dnd, handleReorder }) {
                 }
             })}
             handleReorder={handleReorder}
+            hasCustomSortBy={true}
+            customSortBy={[{
+                id: 'arrival',
+                desc: false
+            }]}
         />
     )
 }

--- a/frontend/src/templates/tables/table.js
+++ b/frontend/src/templates/tables/table.js
@@ -8,7 +8,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 import TablePagination from "./pagination";
 import update from 'immutability-helper';
 
-export function Table({ columns, data, searchOn, searchLabel, ourGlobalFilterFunction, showAll, navUrl, dnd, handleReorder, rowProps = () => ({}) }) {
+export function Table({ columns, data, searchOn, searchLabel, ourGlobalFilterFunction, showAll, navUrl, dnd, handleReorder, hasCustomSortBy, customSortBy, rowProps = () => ({}) }) {
     const navigate = useNavigate();
 
     const handleFilterInputChange = (e) => {
@@ -55,12 +55,12 @@ export function Table({ columns, data, searchOn, searchLabel, ourGlobalFilterFun
             searchInput: "",
             pageIndex: 0,
             pageSize: 10,
-            sortBy: dnd ? [] : [
+            sortBy: dnd ? [] : ( hasCustomSortBy ? customSortBy : [
                 {
                     id: 'name',
                     desc: false
                 }
-            ]
+            ])
         },
         },
         useFilters,
@@ -81,8 +81,8 @@ export function Table({ columns, data, searchOn, searchLabel, ourGlobalFilterFun
         const new_order = new_records.map(row => {
             return row.id
         })
-        console.log(new_records)
-        console.log(new_order)
+        // console.log(new_records)
+        // console.log(new_order)
         handleReorder(new_order)
         setRecords(new_records)
     }

--- a/frontend/src/templates/tables/table.js
+++ b/frontend/src/templates/tables/table.js
@@ -19,6 +19,10 @@ export function Table({ columns, data, searchOn, searchLabel, ourGlobalFilterFun
 
     const [records, setRecords] = useState(data)
 
+    useEffect(() => {
+        setRecords(data)
+    }, [data])
+
     const getRowId = React.useCallback(row => {
         // console.log(row)
         return row.id


### PR DESCRIPTION
- reordering stops will edit on backend and display on frontend! times updating too!!
- NOTE react tables is sorting by 'arrival' instead of order_by  -- this seems to work (?) but its kinda sus @kyratichan if you have any way to sort by a value thats not a column lmk!
- BUG possible: sometimes pressing save on the reorder will cause website to break due (?) to recalling getstops api upon updating backend. hasnt been reproduced for a while at time of pr but who knows